### PR TITLE
Capybara selector

### DIFF
--- a/lib/rspec-2/rails/generators/templates/acceptance_helper.rb
+++ b/lib/rspec-2/rails/generators/templates/acceptance_helper.rb
@@ -21,6 +21,7 @@ RSpec.configuration.include Steak::Webrat, :type => :acceptance
 
 <%- else -%>
 require 'capybara/rails'
+Capybara.default_selector = :css
 
 RSpec.configuration.include Capybara, :type => :acceptance
 <%- end -%>


### PR DESCRIPTION
I made Capybara use css selectors by default rather than xpath. Simple 1-line change in the generated acceptance_helper.rb file. I only changed the rails 3 generator as I am unsure if the change would be different for rails 2.
