### PR TITLE
Reducing Rspec/Rails gem dependencies

### DIFF
--- a/steak.gemspec
+++ b/steak.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'rspec'
   
-  gem.add_development_dependency 'rspec-rails', '>= 2.0.0'
-  gem.add_development_dependency 'rails', '>= 3.0.0'
+  gem.add_development_dependency 'rspec-rails', '>= 1.3'
+  gem.add_development_dependency 'rails', '>= 2.3.0'
   gem.add_development_dependency 'capybara'
   gem.add_development_dependency 'webrat'
   gem.add_development_dependency 'sqlite3-ruby'


### PR DESCRIPTION
Hi, 

Tiny tiny change :)

I've updated the Gemspec to require Rails >= 2.3 (not >= 3) and Rspec >= 1.3 (not >= 2).

Steak actually works with these earlier versions and the higher dependencies in the Gemspec were causing problems for us in our continuous integration builds.

Cheers,
Dave
