### PR TITLE
Running "rails destroy steak:spec ..." empties the spec/acceptance folder

### DIFF
--- a/lib/rspec-2/rails/generators/spec_generator.rb
+++ b/lib/rspec-2/rails/generators/spec_generator.rb
@@ -18,7 +18,10 @@ Example:
 DESC
 
     def manifest
-      empty_directory File.join('spec/acceptance', class_path)
+      if behavior == :invoke
+        empty_directory File.join('spec/acceptance', class_path)
+      end
+
       file_name.gsub!(/_spec$/, "")
 
       @feature_name  = file_name.titleize

--- a/spec/acceptance/rspec-2/steak_spec_generator_spec.rb
+++ b/spec/acceptance/rspec-2/steak_spec_generator_spec.rb
@@ -60,4 +60,18 @@ feature "Acceptance spec generator for rails", %q{
     File.exist?(file_path).should be_true
     File.read(file_path).should include("/../acceptance_helper")
   end
+
+  scenario "Removing an acceptance spec" do
+    Dir.chdir @rails_app do
+      run "rails generate steak:spec document_creation"
+      run "rails destroy steak:spec document_creation"
+    end
+
+    spec_dir = @rails_app + "/spec/acceptance/"
+    
+    File.exist?(spec_dir + "document_creation_spec.rb").should be_false
+    File.exist?(spec_dir + "acceptance_helper.rb").should be_true
+    File.exist?(spec_dir + "support/helpers.rb").should be_true
+    File.exist?(spec_dir + "support/paths.rb").should be_true
+  end
 end


### PR DESCRIPTION
The #empty_directory method from Thor can only be executed when running "rails generate" and not "rails destroy", or it ends up cleaning up the whole spec/acceptance directory.

Shame I found this bug before committing some changes. Anyway, it's fixed and spec'ed now.
