### PR TITLE
Change the rspec dependency to ~> 1.3

### DIFF
--- a/steak.gemspec
+++ b/steak.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.files = Dir['init.rb', 'MIT-LICENSE', 'Rakefile', 'README*', 'LICENSE*',
                   '{lib,spec,generators}/**/*'] & `git ls-files -z`.split("\0")
 
-  gem.add_dependency 'rspec', '>= 1.3'
+  gem.add_dependency 'rspec', '~> 1.3'
   
   gem.add_development_dependency 'rspec-rails', '>= 2.0.0'
   gem.add_development_dependency 'rails', '>= 3.0.0'


### PR DESCRIPTION
Depending on rspec >= 1.3 installs rspec 2.0. When using Rails 2.3, and not using bundler, that could be a problem.
